### PR TITLE
fix category incorrect hierarchical issue [SPMVP-5010]

### DIFF
--- a/class-storipress.php
+++ b/class-storipress.php
@@ -223,6 +223,10 @@ final class Storipress {
 					)
 				);
 
+				if ( empty( $items ) ) {
+					continue;
+				}
+
 				array_push( $categories, ...$items );
 
 				array_push( $temp, ...$items );

--- a/class-storipress.php
+++ b/class-storipress.php
@@ -223,9 +223,9 @@ final class Storipress {
 					)
 				);
 
-				array_push($categories, ...$items);
+				array_push( $categories, ...$items );
 
-				array_push($temp, ...$items);
+				array_push( $temp, ...$items );
 			}
 
 			$parents = array_map(
@@ -236,7 +236,7 @@ final class Storipress {
 			);
 
 			$parents = array_values( array_unique( $parents ) );
-		} while ( ! empty( $parents ) ) ;
+		} while ( ! empty( $parents ) );
 
 		foreach ( $categories as $category ) {
 			$this->flush( 'category', $category->to_array() );


### PR DESCRIPTION
### The Problem

When exporting categories with a hierarchical structure, the original sorting issue may cause errors in the order, which could then lead to problems during the import process, such as being unable to find the parent category.

### JIRA Issues

- https://storipress-media.atlassian.net/browse/SPMVP-5010

### Sentry Issues

- https://storipress.sentry.io/issues/4013331232/

### Reproducing Steps

1. Create categories with a hierarchical structure. <img width="1108" alt="image" src="https://user-images.githubusercontent.com/8221099/226269013-66d13f3b-7fee-4459-8a19-95effa2f7690.png">
2. Move the top-level category with a smaller ID below another top-level category. <img width="1101" alt="image" src="https://user-images.githubusercontent.com/8221099/226269076-f200e668-0e24-490b-a234-68ca3770fd32.png">
3. Export data using the Storipress plugin.

---

### The Solution

During the export process, start from the top level and export sequentially down to lower levels, rather than retrieving all at once and then sorting.

### Unsolved Problems

N/A

### Side Effects

N/A

### JIRA Tracking

N/A

---

### Checklist Before Requesting a Review

- [x] all actions tests are passed
- [ ] there are new tests to cover the problem
- [ ] docker image has data corresponding to the problem
- [x] there are new JIRA issues, if needed, to track side effects and unsolved problems
- [x] the new JIRA issues, if present, have added linked issues

---

### References

- https://developer.wordpress.org/reference/functions/get_terms/
